### PR TITLE
fixing akdev ops slack link, re-arrange content

### DIFF
--- a/content/card/connect.md
+++ b/content/card/connect.md
@@ -9,18 +9,10 @@ Fairbanks Hackathon provides the community a few methods of connecting with each
 
 [Fairbanks Hackathon GitHub organization](https://github.com/FairbanksHackathon)
 
-<i class="fa fa-comments-o fa-2x" aria-hidden="true"></i>
-
-Chat with fellow Fairbanks Hackers.
-
-<i class="fa fa-slack fa-2x" aria-hidden="true"></i>
-
-[Alaska DevOps Slack](https://akdevops.slack.com) - a chat community for systems, developers, and enthusiasts of [DevOps](https://en.wikipedia.org/wiki/DevOps).
-
-<i class="fa fa-comment-o fa-2x" aria-hidden="true"></i>
+<i class="fa fa-comments-o fa-3x" aria-hidden="true"></i>
 
 Fairbanks Hackathon has a [Gitter](gitter.im) [FairbanksHackathon Lobby](https://gitter.im/FairbanksHackathon/Lobby) chat channel. We use this to help plan events and provide a central chat channel during events. Just need a [GitHub](https://github.com) identity to join!
 
-<i class="fa fa-lightbulb-o fa-2x" aria-hidden="true"></i>
+<i class="fa fa-lightbulb-o fa-3x" aria-hidden="true"></i>
 
-We also use our issue tracker to collect and organize hacking ideas for hackathons.  If you have an idea or problem you think would be great to be put forward during a hackathon event toss it into our [website issue tracker](https://github.com/FairbanksHackathon/fairbankshackathon.github.io/issues).
+We also use our [issue tracker](https://github.com/FairbanksHackathon/fairbankshackathon.github.io/issues) to collect and organize hacking ideas for hackathons.  If you have an idea or problem you think would be great to be put forward during a hackathon event toss it into our [website issue tracker](https://github.com/FairbanksHackathon/fairbankshackathon.github.io/issues).

--- a/content/card/meta.md
+++ b/content/card/meta.md
@@ -10,11 +10,11 @@ weight = 1
 
 We want [Fairbanks Hackathon](/) to be an open and inclusive community. We have a public [GitHub organization](https://github.com/FairbanksHackathon) for projects managed by the FBXHAX community. Our website, both the source content and site hosting, is on GitHub as a public repository.
 
-<i class="fa fa-github-alt fa-2x" aria-hidden="true"></i>
+<i class="fa fa-github-alt fa-3x" aria-hidden="true"></i>
 
 If you do not already have a GitHub account create one and we encourage you to star, or even watch, our [website repository](https://github.com/FairbanksHackathon/fairbankshackathon.github.io) on GitHub.
 
-<i class="fa fa-bug fa-2x" aria-hidden="true"></i>
+<i class="fa fa-bug fa-3x" aria-hidden="true"></i>
 
 You are encouraged to help us improve the website through reporting bugs/ideas/content on our [issue tracker](https://github.com/FairbanksHackathon/fairbankshackathon.github.io/issues). Even better learn how to hack directly on the website.  
 

--- a/content/card/partners.md
+++ b/content/card/partners.md
@@ -16,3 +16,7 @@ Support for the Fairbanks Hackathon community as a component in the growth and d
 [UAF Office of Intellectual Property and Commercialization](http://www.uaf.edu/oipc/)
 
 [Alaska Small Business Development](https://aksbdc.org/)
+
+<i class="fa fa-slack fa-3x" aria-hidden="true"></i>
+
+[Alaska DevOps Slack](https://slack.akdevops.org/) - a chat community for systems, developers, and enthusiasts of [DevOps](https://en.wikipedia.org/wiki/DevOps).

--- a/public/card/connect/index.html
+++ b/public/card/connect/index.html
@@ -34,21 +34,13 @@
 
 <p><a href="https://github.com/FairbanksHackathon">Fairbanks Hackathon GitHub organization</a></p>
 
-<p><i class="fa fa-comments-o fa-2x" aria-hidden="true"></i></p>
-
-<p>Chat with fellow Fairbanks Hackers.</p>
-
-<p><i class="fa fa-slack fa-2x" aria-hidden="true"></i></p>
-
-<p><a href="https://akdevops.slack.com">Alaska DevOps Slack</a> - a chat community for systems, developers, and enthusiasts of <a href="https://en.wikipedia.org/wiki/DevOps">DevOps</a>.</p>
-
-<p><i class="fa fa-comment-o fa-2x" aria-hidden="true"></i></p>
+<p><i class="fa fa-comments-o fa-3x" aria-hidden="true"></i></p>
 
 <p>Fairbanks Hackathon has a <a href="gitter.im">Gitter</a> <a href="https://gitter.im/FairbanksHackathon/Lobby">FairbanksHackathon Lobby</a> chat channel. We use this to help plan events and provide a central chat channel during events. Just need a <a href="https://github.com">GitHub</a> identity to join!</p>
 
-<p><i class="fa fa-lightbulb-o fa-2x" aria-hidden="true"></i></p>
+<p><i class="fa fa-lightbulb-o fa-3x" aria-hidden="true"></i></p>
 
-<p>We also use our issue tracker to collect and organize hacking ideas for hackathons.  If you have an idea or problem you think would be great to be put forward during a hackathon event toss it into our <a href="https://github.com/FairbanksHackathon/fairbankshackathon.github.io/issues">website issue tracker</a>.</p>
+<p>We also use our <a href="https://github.com/FairbanksHackathon/fairbankshackathon.github.io/issues">issue tracker</a> to collect and organize hacking ideas for hackathons.  If you have an idea or problem you think would be great to be put forward during a hackathon event toss it into our <a href="https://github.com/FairbanksHackathon/fairbankshackathon.github.io/issues">website issue tracker</a>.</p>
 
   </div>
 </div>

--- a/public/card/index.xml
+++ b/public/card/index.xml
@@ -17,11 +17,11 @@
       <guid>https://fairbankshackathon.github.io/card/meta/</guid>
       <description>&lt;p&gt;We want &lt;a href=&#34;https://fairbankshackathon.github.io/&#34;&gt;Fairbanks Hackathon&lt;/a&gt; to be an open and inclusive community. We have a public &lt;a href=&#34;https://github.com/FairbanksHackathon&#34;&gt;GitHub organization&lt;/a&gt; for projects managed by the FBXHAX community. Our website, both the source content and site hosting, is on GitHub as a public repository.&lt;/p&gt;
 
-&lt;p&gt;&lt;i class=&#34;fa fa-github-alt fa-2x&#34; aria-hidden=&#34;true&#34;&gt;&lt;/i&gt;&lt;/p&gt;
+&lt;p&gt;&lt;i class=&#34;fa fa-github-alt fa-3x&#34; aria-hidden=&#34;true&#34;&gt;&lt;/i&gt;&lt;/p&gt;
 
 &lt;p&gt;If you do not already have a GitHub account create one and we encourage you to star, or even watch, our &lt;a href=&#34;https://github.com/FairbanksHackathon/fairbankshackathon.github.io&#34;&gt;website repository&lt;/a&gt; on GitHub.&lt;/p&gt;
 
-&lt;p&gt;&lt;i class=&#34;fa fa-bug fa-2x&#34; aria-hidden=&#34;true&#34;&gt;&lt;/i&gt;&lt;/p&gt;
+&lt;p&gt;&lt;i class=&#34;fa fa-bug fa-3x&#34; aria-hidden=&#34;true&#34;&gt;&lt;/i&gt;&lt;/p&gt;
 
 &lt;p&gt;You are encouraged to help us improve the website through reporting bugs/ideas/content on our &lt;a href=&#34;https://github.com/FairbanksHackathon/fairbankshackathon.github.io/issues&#34;&gt;issue tracker&lt;/a&gt;. Even better learn how to hack directly on the website.&lt;/p&gt;
 
@@ -41,21 +41,13 @@
 
 &lt;p&gt;&lt;a href=&#34;https://github.com/FairbanksHackathon&#34;&gt;Fairbanks Hackathon GitHub organization&lt;/a&gt;&lt;/p&gt;
 
-&lt;p&gt;&lt;i class=&#34;fa fa-comments-o fa-2x&#34; aria-hidden=&#34;true&#34;&gt;&lt;/i&gt;&lt;/p&gt;
-
-&lt;p&gt;Chat with fellow Fairbanks Hackers.&lt;/p&gt;
-
-&lt;p&gt;&lt;i class=&#34;fa fa-slack fa-2x&#34; aria-hidden=&#34;true&#34;&gt;&lt;/i&gt;&lt;/p&gt;
-
-&lt;p&gt;&lt;a href=&#34;https://akdevops.slack.com&#34;&gt;Alaska DevOps Slack&lt;/a&gt; - a chat community for systems, developers, and enthusiasts of &lt;a href=&#34;https://en.wikipedia.org/wiki/DevOps&#34;&gt;DevOps&lt;/a&gt;.&lt;/p&gt;
-
-&lt;p&gt;&lt;i class=&#34;fa fa-comment-o fa-2x&#34; aria-hidden=&#34;true&#34;&gt;&lt;/i&gt;&lt;/p&gt;
+&lt;p&gt;&lt;i class=&#34;fa fa-comments-o fa-3x&#34; aria-hidden=&#34;true&#34;&gt;&lt;/i&gt;&lt;/p&gt;
 
 &lt;p&gt;Fairbanks Hackathon has a &lt;a href=&#34;gitter.im&#34;&gt;Gitter&lt;/a&gt; &lt;a href=&#34;https://gitter.im/FairbanksHackathon/Lobby&#34;&gt;FairbanksHackathon Lobby&lt;/a&gt; chat channel. We use this to help plan events and provide a central chat channel during events. Just need a &lt;a href=&#34;https://github.com&#34;&gt;GitHub&lt;/a&gt; identity to join!&lt;/p&gt;
 
-&lt;p&gt;&lt;i class=&#34;fa fa-lightbulb-o fa-2x&#34; aria-hidden=&#34;true&#34;&gt;&lt;/i&gt;&lt;/p&gt;
+&lt;p&gt;&lt;i class=&#34;fa fa-lightbulb-o fa-3x&#34; aria-hidden=&#34;true&#34;&gt;&lt;/i&gt;&lt;/p&gt;
 
-&lt;p&gt;We also use our issue tracker to collect and organize hacking ideas for hackathons.  If you have an idea or problem you think would be great to be put forward during a hackathon event toss it into our &lt;a href=&#34;https://github.com/FairbanksHackathon/fairbankshackathon.github.io/issues&#34;&gt;website issue tracker&lt;/a&gt;.&lt;/p&gt;
+&lt;p&gt;We also use our &lt;a href=&#34;https://github.com/FairbanksHackathon/fairbankshackathon.github.io/issues&#34;&gt;issue tracker&lt;/a&gt; to collect and organize hacking ideas for hackathons.  If you have an idea or problem you think would be great to be put forward during a hackathon event toss it into our &lt;a href=&#34;https://github.com/FairbanksHackathon/fairbankshackathon.github.io/issues&#34;&gt;website issue tracker&lt;/a&gt;.&lt;/p&gt;
 </description>
     </item>
     
@@ -74,6 +66,10 @@
 &lt;p&gt;&lt;a href=&#34;http://www.uaf.edu/oipc/&#34;&gt;UAF Office of Intellectual Property and Commercialization&lt;/a&gt;&lt;/p&gt;
 
 &lt;p&gt;&lt;a href=&#34;https://aksbdc.org/&#34;&gt;Alaska Small Business Development&lt;/a&gt;&lt;/p&gt;
+
+&lt;p&gt;&lt;i class=&#34;fa fa-slack fa-3x&#34; aria-hidden=&#34;true&#34;&gt;&lt;/i&gt;&lt;/p&gt;
+
+&lt;p&gt;&lt;a href=&#34;https://slack.akdevops.org/&#34;&gt;Alaska DevOps Slack&lt;/a&gt; - a chat community for systems, developers, and enthusiasts of &lt;a href=&#34;https://en.wikipedia.org/wiki/DevOps&#34;&gt;DevOps&lt;/a&gt;.&lt;/p&gt;
 </description>
     </item>
     

--- a/public/card/meta/index.html
+++ b/public/card/meta/index.html
@@ -32,11 +32,11 @@
   <div>
     <p>We want <a href="https://fairbankshackathon.github.io/">Fairbanks Hackathon</a> to be an open and inclusive community. We have a public <a href="https://github.com/FairbanksHackathon">GitHub organization</a> for projects managed by the FBXHAX community. Our website, both the source content and site hosting, is on GitHub as a public repository.</p>
 
-<p><i class="fa fa-github-alt fa-2x" aria-hidden="true"></i></p>
+<p><i class="fa fa-github-alt fa-3x" aria-hidden="true"></i></p>
 
 <p>If you do not already have a GitHub account create one and we encourage you to star, or even watch, our <a href="https://github.com/FairbanksHackathon/fairbankshackathon.github.io">website repository</a> on GitHub.</p>
 
-<p><i class="fa fa-bug fa-2x" aria-hidden="true"></i></p>
+<p><i class="fa fa-bug fa-3x" aria-hidden="true"></i></p>
 
 <p>You are encouraged to help us improve the website through reporting bugs/ideas/content on our <a href="https://github.com/FairbanksHackathon/fairbankshackathon.github.io/issues">issue tracker</a>. Even better learn how to hack directly on the website.</p>
 

--- a/public/card/partners/index.html
+++ b/public/card/partners/index.html
@@ -40,6 +40,10 @@
 
 <p><a href="https://aksbdc.org/">Alaska Small Business Development</a></p>
 
+<p><i class="fa fa-slack fa-3x" aria-hidden="true"></i></p>
+
+<p><a href="https://slack.akdevops.org/">Alaska DevOps Slack</a> - a chat community for systems, developers, and enthusiasts of <a href="https://en.wikipedia.org/wiki/DevOps">DevOps</a>.</p>
+
   </div>
 </div>
 

--- a/public/index.html
+++ b/public/index.html
@@ -27,29 +27,6 @@
 
 
 
-<div class="introduction">
-  <div class="dark-bg">
-    <div class="intro-content container">
-      <div class="row">
-        <div class="col-sm-6 text-xs-right lead">
-          
-
-<h1 id="fairbanks-hackathon">Fairbanks Hackathon</h1>
-
-<p>A public forum to organize and encourage the growth of a hacking community in Fairbanks Alaska. Fairbanks Hackathon website and events allow passionate hackers to collaborate, connect and tackle interesting problems. The Fairbanks Hackathon GitHub organization allows the community to collect and iterate on ideas and challenges relevant to interior Alaska.</p>
-
-        </div>
-        <div class="col-sm-6 text-xs-right">
-          <img class="img-responsive" src="img/glider-trans-50.png" />
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-
-
-
   <div class="card">
     <div class="card-block">
       <div class="row">
@@ -78,6 +55,29 @@
   </div>
 
 
+
+<div class="introduction">
+  <div class="dark-bg">
+    <div class="intro-content container">
+      <div class="row">
+        <div class="col-sm-6 text-xs-right lead">
+          
+
+<h1 id="fairbanks-hackathon">Fairbanks Hackathon</h1>
+
+<p>A public forum to organize and encourage the growth of a hacking community in Fairbanks Alaska. Fairbanks Hackathon website and events allow passionate hackers to collaborate, connect and tackle interesting problems. The Fairbanks Hackathon GitHub organization allows the community to collect and iterate on ideas and challenges relevant to interior Alaska.</p>
+
+        </div>
+        <div class="col-sm-6 text-xs-right">
+          <img class="img-responsive" src="img/glider-trans-50.png" />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+
 <div class="more-info container-fluid">
   <div class="card-deck-wrapper">
     <div class="card-deck">
@@ -93,11 +93,11 @@
           <p class="card-text">
             <p>We want <a href="https://fairbankshackathon.github.io/">Fairbanks Hackathon</a> to be an open and inclusive community. We have a public <a href="https://github.com/FairbanksHackathon">GitHub organization</a> for projects managed by the FBXHAX community. Our website, both the source content and site hosting, is on GitHub as a public repository.</p>
 
-<p><i class="fa fa-github-alt fa-2x" aria-hidden="true"></i></p>
+<p><i class="fa fa-github-alt fa-3x" aria-hidden="true"></i></p>
 
 <p>If you do not already have a GitHub account create one and we encourage you to star, or even watch, our <a href="https://github.com/FairbanksHackathon/fairbankshackathon.github.io">website repository</a> on GitHub.</p>
 
-<p><i class="fa fa-bug fa-2x" aria-hidden="true"></i></p>
+<p><i class="fa fa-bug fa-3x" aria-hidden="true"></i></p>
 
 <p>You are encouraged to help us improve the website through reporting bugs/ideas/content on our <a href="https://github.com/FairbanksHackathon/fairbankshackathon.github.io/issues">issue tracker</a>. Even better learn how to hack directly on the website.</p>
 
@@ -123,21 +123,13 @@
 
 <p><a href="https://github.com/FairbanksHackathon">Fairbanks Hackathon GitHub organization</a></p>
 
-<p><i class="fa fa-comments-o fa-2x" aria-hidden="true"></i></p>
-
-<p>Chat with fellow Fairbanks Hackers.</p>
-
-<p><i class="fa fa-slack fa-2x" aria-hidden="true"></i></p>
-
-<p><a href="https://akdevops.slack.com">Alaska DevOps Slack</a> - a chat community for systems, developers, and enthusiasts of <a href="https://en.wikipedia.org/wiki/DevOps">DevOps</a>.</p>
-
-<p><i class="fa fa-comment-o fa-2x" aria-hidden="true"></i></p>
+<p><i class="fa fa-comments-o fa-3x" aria-hidden="true"></i></p>
 
 <p>Fairbanks Hackathon has a <a href="gitter.im">Gitter</a> <a href="https://gitter.im/FairbanksHackathon/Lobby">FairbanksHackathon Lobby</a> chat channel. We use this to help plan events and provide a central chat channel during events. Just need a <a href="https://github.com">GitHub</a> identity to join!</p>
 
-<p><i class="fa fa-lightbulb-o fa-2x" aria-hidden="true"></i></p>
+<p><i class="fa fa-lightbulb-o fa-3x" aria-hidden="true"></i></p>
 
-<p>We also use our issue tracker to collect and organize hacking ideas for hackathons.  If you have an idea or problem you think would be great to be put forward during a hackathon event toss it into our <a href="https://github.com/FairbanksHackathon/fairbankshackathon.github.io/issues">website issue tracker</a>.</p>
+<p>We also use our <a href="https://github.com/FairbanksHackathon/fairbankshackathon.github.io/issues">issue tracker</a> to collect and organize hacking ideas for hackathons.  If you have an idea or problem you think would be great to be put forward during a hackathon event toss it into our <a href="https://github.com/FairbanksHackathon/fairbankshackathon.github.io/issues">website issue tracker</a>.</p>
 
           </p>
           <a href="https://fairbankshackathon.github.io/card/connect/">...</a>
@@ -162,6 +154,10 @@
 <p><a href="http://www.uaf.edu/oipc/">UAF Office of Intellectual Property and Commercialization</a></p>
 
 <p><a href="https://aksbdc.org/">Alaska Small Business Development</a></p>
+
+<p><i class="fa fa-slack fa-3x" aria-hidden="true"></i></p>
+
+<p><a href="https://slack.akdevops.org/">Alaska DevOps Slack</a> - a chat community for systems, developers, and enthusiasts of <a href="https://en.wikipedia.org/wiki/DevOps">DevOps</a>.</p>
 
           </p>
           <a href="https://fairbankshackathon.github.io/card/partners/">...</a>

--- a/public/index.xml
+++ b/public/index.xml
@@ -77,11 +77,11 @@
       <guid>https://fairbankshackathon.github.io/card/meta/</guid>
       <description>&lt;p&gt;We want &lt;a href=&#34;https://fairbankshackathon.github.io/&#34;&gt;Fairbanks Hackathon&lt;/a&gt; to be an open and inclusive community. We have a public &lt;a href=&#34;https://github.com/FairbanksHackathon&#34;&gt;GitHub organization&lt;/a&gt; for projects managed by the FBXHAX community. Our website, both the source content and site hosting, is on GitHub as a public repository.&lt;/p&gt;
 
-&lt;p&gt;&lt;i class=&#34;fa fa-github-alt fa-2x&#34; aria-hidden=&#34;true&#34;&gt;&lt;/i&gt;&lt;/p&gt;
+&lt;p&gt;&lt;i class=&#34;fa fa-github-alt fa-3x&#34; aria-hidden=&#34;true&#34;&gt;&lt;/i&gt;&lt;/p&gt;
 
 &lt;p&gt;If you do not already have a GitHub account create one and we encourage you to star, or even watch, our &lt;a href=&#34;https://github.com/FairbanksHackathon/fairbankshackathon.github.io&#34;&gt;website repository&lt;/a&gt; on GitHub.&lt;/p&gt;
 
-&lt;p&gt;&lt;i class=&#34;fa fa-bug fa-2x&#34; aria-hidden=&#34;true&#34;&gt;&lt;/i&gt;&lt;/p&gt;
+&lt;p&gt;&lt;i class=&#34;fa fa-bug fa-3x&#34; aria-hidden=&#34;true&#34;&gt;&lt;/i&gt;&lt;/p&gt;
 
 &lt;p&gt;You are encouraged to help us improve the website through reporting bugs/ideas/content on our &lt;a href=&#34;https://github.com/FairbanksHackathon/fairbankshackathon.github.io/issues&#34;&gt;issue tracker&lt;/a&gt;. Even better learn how to hack directly on the website.&lt;/p&gt;
 
@@ -101,21 +101,13 @@
 
 &lt;p&gt;&lt;a href=&#34;https://github.com/FairbanksHackathon&#34;&gt;Fairbanks Hackathon GitHub organization&lt;/a&gt;&lt;/p&gt;
 
-&lt;p&gt;&lt;i class=&#34;fa fa-comments-o fa-2x&#34; aria-hidden=&#34;true&#34;&gt;&lt;/i&gt;&lt;/p&gt;
-
-&lt;p&gt;Chat with fellow Fairbanks Hackers.&lt;/p&gt;
-
-&lt;p&gt;&lt;i class=&#34;fa fa-slack fa-2x&#34; aria-hidden=&#34;true&#34;&gt;&lt;/i&gt;&lt;/p&gt;
-
-&lt;p&gt;&lt;a href=&#34;https://akdevops.slack.com&#34;&gt;Alaska DevOps Slack&lt;/a&gt; - a chat community for systems, developers, and enthusiasts of &lt;a href=&#34;https://en.wikipedia.org/wiki/DevOps&#34;&gt;DevOps&lt;/a&gt;.&lt;/p&gt;
-
-&lt;p&gt;&lt;i class=&#34;fa fa-comment-o fa-2x&#34; aria-hidden=&#34;true&#34;&gt;&lt;/i&gt;&lt;/p&gt;
+&lt;p&gt;&lt;i class=&#34;fa fa-comments-o fa-3x&#34; aria-hidden=&#34;true&#34;&gt;&lt;/i&gt;&lt;/p&gt;
 
 &lt;p&gt;Fairbanks Hackathon has a &lt;a href=&#34;gitter.im&#34;&gt;Gitter&lt;/a&gt; &lt;a href=&#34;https://gitter.im/FairbanksHackathon/Lobby&#34;&gt;FairbanksHackathon Lobby&lt;/a&gt; chat channel. We use this to help plan events and provide a central chat channel during events. Just need a &lt;a href=&#34;https://github.com&#34;&gt;GitHub&lt;/a&gt; identity to join!&lt;/p&gt;
 
-&lt;p&gt;&lt;i class=&#34;fa fa-lightbulb-o fa-2x&#34; aria-hidden=&#34;true&#34;&gt;&lt;/i&gt;&lt;/p&gt;
+&lt;p&gt;&lt;i class=&#34;fa fa-lightbulb-o fa-3x&#34; aria-hidden=&#34;true&#34;&gt;&lt;/i&gt;&lt;/p&gt;
 
-&lt;p&gt;We also use our issue tracker to collect and organize hacking ideas for hackathons.  If you have an idea or problem you think would be great to be put forward during a hackathon event toss it into our &lt;a href=&#34;https://github.com/FairbanksHackathon/fairbankshackathon.github.io/issues&#34;&gt;website issue tracker&lt;/a&gt;.&lt;/p&gt;
+&lt;p&gt;We also use our &lt;a href=&#34;https://github.com/FairbanksHackathon/fairbankshackathon.github.io/issues&#34;&gt;issue tracker&lt;/a&gt; to collect and organize hacking ideas for hackathons.  If you have an idea or problem you think would be great to be put forward during a hackathon event toss it into our &lt;a href=&#34;https://github.com/FairbanksHackathon/fairbankshackathon.github.io/issues&#34;&gt;website issue tracker&lt;/a&gt;.&lt;/p&gt;
 </description>
     </item>
     
@@ -134,6 +126,10 @@
 &lt;p&gt;&lt;a href=&#34;http://www.uaf.edu/oipc/&#34;&gt;UAF Office of Intellectual Property and Commercialization&lt;/a&gt;&lt;/p&gt;
 
 &lt;p&gt;&lt;a href=&#34;https://aksbdc.org/&#34;&gt;Alaska Small Business Development&lt;/a&gt;&lt;/p&gt;
+
+&lt;p&gt;&lt;i class=&#34;fa fa-slack fa-3x&#34; aria-hidden=&#34;true&#34;&gt;&lt;/i&gt;&lt;/p&gt;
+
+&lt;p&gt;&lt;a href=&#34;https://slack.akdevops.org/&#34;&gt;Alaska DevOps Slack&lt;/a&gt; - a chat community for systems, developers, and enthusiasts of &lt;a href=&#34;https://en.wikipedia.org/wiki/DevOps&#34;&gt;DevOps&lt;/a&gt;.&lt;/p&gt;
 </description>
     </item>
     

--- a/themes/fbxhackathon/layouts/index.html
+++ b/themes/fbxhackathon/layouts/index.html
@@ -1,5 +1,5 @@
 {{ partial "header.html" . }}
-{{ partial "banner.html" . }}
 {{ partial "event.html"  . }}
+{{ partial "banner.html" . }}
 {{ partial "cards.html" . }}
 {{ partial "footer.html" . }}


### PR DESCRIPTION
Started off with a minor URL fix and decided to re-arrange content a bit.  

* moved event to top of page -- after event this will be removed/archived
* moved AkDevOps into Partners section
* Increased those icons in general (hopefully not a mistake for others on low resolution monitors)